### PR TITLE
prependを最小限に

### DIFF
--- a/lib/n1_safe.rb
+++ b/lib/n1_safe.rb
@@ -8,7 +8,7 @@ require_relative 'n1_safe/base_class'
 require_relative 'n1_safe/relation'
 
 ActiveRecord::Base.singleton_class.class_eval do
-  prepend N1Safe::BaseClass
+  include N1Safe::BaseClass
   def n1_safe
     all.n1_safe
   end
@@ -16,7 +16,7 @@ end
 
 
 ActiveRecord::Base.class_eval do
-  prepend N1Safe::Model
+  include N1Safe::Model
 end
 
 ActiveRecord::Associations::CollectionProxy.class_eval do

--- a/lib/n1_safe/base_class.rb
+++ b/lib/n1_safe/base_class.rb
@@ -1,33 +1,27 @@
 module N1Safe::BaseClass
-  def n1_safe_module
-    unless @n1_safe_module
-      @n1_safe_module = Module.new
-      prepend @n1_safe_module
-    end
-    @n1_safe_module
-  end
-
-  def n1_safe_define name, multiple: false
-    n1_safe_module.send :define_method, name do
-      return super() unless n1_safe?
+  def n1_safe_define_association name, multiple: false
+    original_method = "#{name}_without_n1_safe"
+    define_method "#{name}_with_n1_safe" do
+      return send original_method unless n1_safe?
       if @n1_safe
         n1_safe_preload name unless multiple
-        child = super()
+        child = send original_method
         child.n1_safe_set root: @n1_safe[:root], path: [*@n1_safe[:path], name], parent: self if child
       end
     end
+    alias_method_chain name, :n1_safe
   end
 
   def has_many name, *args
-    n1_safe_define name, multiple: true
     super
+    n1_safe_define_association name, multiple: true
   end
   def has_one name, *args
-    n1_safe_define name
     super
+    n1_safe_define_association name
   end
   def belongs_to name, *args
-    n1_safe_define name
     super
+    n1_safe_define_association name
   end
 end


### PR DESCRIPTION
``` ruby
has_many :foos
alias_method_chain :foos, :bar
```

でstack level too deep が出る問題を回避
prependとalias_method_chainの組み合わせが駄目ぽい
